### PR TITLE
Fix composer json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.0",
-        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*|7.0.*",
-        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.0.*|7.0.*",
+        "illuminate/contracts": "5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*",
+        "illuminate/support": "5.5.*|5.6.*|5.7.*|5.8.*|6.*|7.*",
         "graham-campbell/manager": "^3.0|^4.0",
         "pusher/pusher-push-notifications": "^1.0"
     },


### PR DESCRIPTION
The `composer.json` file was requiring to have the minor version set to 0 for Laravel 6 and 7.